### PR TITLE
Utm3145scopes to swagger

### DIFF
--- a/fims-api/swagger.yaml
+++ b/fims-api/swagger.yaml
@@ -36,13 +36,14 @@ tags: # Have to add 'A' 'B' etc since ordering isn't respected in SwaggerUI.
 securityDefinitions:
   fims_ops_security:
     type: oauth2
-    tokenUrl: http://thisserver/oauth/token
+    tokenUrl: http://utm.defined.host/oauth/token
     flow: application
     scopes:
       'utm.nasa.gov_write.operation': Subject can read, create, and update operational data such as operation plans and position reports
-      'utm.nasa.gov_read.operation': Subject can read operational data such as operation plans and position reports
       'utm.nasa.gov_write.message': Subject can read, create, and update UTM message data
-      'utm.nasa.gov_read.message': Subject can read UTM message data
+      'utm.nasa.gov_write.constraint': Subject can read, create, and update UTM constraint data. This means that the Subject can define areas that restrict other operations.
+      'utm.nasa.gov_read.fimsadmin': Subject can read data internal to FIMS.
+
 responses:
   WRONG_PROTOCOL:
     description: A RESTful call was made to this endpoint but this is not a REST endpoint. Do not use this endpoint for REST calls.

--- a/fimsauthz-api/swagger.yaml
+++ b/fimsauthz-api/swagger.yaml
@@ -29,11 +29,10 @@ securityDefinitions:
       'utm.nasa.gov_write.publicsafety': Subject can read, create, and update operations that are designated public safety operations.
       'utm.nasa.gov_read.constraint': Subject can read UTM constraint data
       'utm.nasa.gov_write.constraint': Subject can read, create, and update UTM constraint data. This means that the Subject can define areas that restrict other operations.
-      'utm.nasa.gov_read_min.uvin': Subject can read redacted vehicle registration data.
       'utm.nasa.gov_read.uvin':  Subject can read vehicle registration data.
       'utm.nasa.gov_write.uvin':  Subject can read and write vehicle registration data.
-      'utm.nasa.gov_read.stategic_cm':  Subject can read strategic conflict management data.
-      'utm.nasa.gov_write.stategic_cm':  Subject can read and write strategic conflict management data.
+      'utm.nasa.gov_read.conflictmanagement':  Subject can read conflict management data.
+      'utm.nasa.gov_write.conflictmanagement':  Subject can read and write conflict management data.
 
   authenticate_using_client_credentials:
     type: basic

--- a/fimsauthz-api/swagger.yaml
+++ b/fimsauthz-api/swagger.yaml
@@ -33,7 +33,7 @@ securityDefinitions:
       'utm.nasa.gov_read.uvin':  Subject can read vehicle registration data.
       'utm.nasa.gov_write.uvin':  Subject can read and write vehicle registration data.
       'utm.nasa.gov_read.stategic_cm':  Subject can read strategic conflict management data.
-      'utm.nasa.gov_write.stategic_cm':  Subject can read, write (and lock) strategic conflict management data.
+      'utm.nasa.gov_write.stategic_cm':  Subject can read and write strategic conflict management data.
 
   authenticate_using_client_credentials:
     type: basic

--- a/fimsauthz-api/utm-roles.yaml
+++ b/fimsauthz-api/utm-roles.yaml
@@ -8,7 +8,7 @@ UTM_AUTHORITY:
     description: |
       A small set of trusted users who manage identities of all core UTM
       components such as USSs.
-    identity_manager: ANSP
+    authority: ANSP
     examples:
       - "UTM Authority vets USS1's additional capability for Public Service, and adds the PUBLIC_SAFETY role to USS1 in the master list."
       - "UTM Authority vets USS1, then adds an entry to master USS list and assigns the USS_BASIC role."
@@ -22,7 +22,7 @@ FIMS_ADMIN:
         Authentication (MFA) should be enforced users with this role,
         and the number of users with this role should be minimized.
         This role is typically associated with a User whose authorization is out of band WRT FIMS oauth.
-    identity_manager: UTM_AUTHORITY
+    authority: UTM_AUTHORITY
     examples:
         - "An IT admin manages FIMS-AZ logfiles."
         - "An IT admin reads the master USS list to update FIMS-AZ's data table containing the USSs, their scopes and their credentials."
@@ -33,28 +33,28 @@ FIMS_SME:
         manages airspace constraints and other aeronautical data
         This user could be a client to the FIMS Ops server using a User Interface (rather than CLI).
         This role is typically associated with a user whose authorization is out of band WRT FIMS oauth.
-    identity_manager: ANSP
+    authority: ANSP
     examples:
         - "An airspace Subject Matter Expert composes an airspace constraint and submits this constraint to FIMS_OPS."
 
 FIMS_AUTHZ:
     description: This is the service role supporting the FIMS Authorization server.
     This role cannot create, modify or delete UTM Identity data, rather access is read-only.
-    identity_manager: UTM_AUTHORITY
+    authority: UTM_AUTHORITY
     examples:
         - "When FIMS AZ services the token endpoint, it reads a data table containing USS identities and their scopes."
 
 FIMS_OPS:
     description: This role manages the interface between the USS Network and
     the ANSP.  This role is assigned to the FIMS_OPS server.
-    identity_manager: UTM_AUTHORITY
+    authority: UTM_AUTHORITY
     examples:
         - "FIMS_OPS is authorized to inject an airspace constraint to the USS Network."
     scopes:
         - utm.nasa.gov_write.constraint
 
 VEHICLE_AUTHORITY:
-    identity_manager: TBD; May be a set of trusted commercial entities
+    authority: TBD; May be a set of trusted commercial entities
     description: |
       This role allows creation, modifcation and deletion of vehicle registrations.
       This role is typically associated with a user whose authentication and
@@ -67,7 +67,7 @@ VEHICLE_REGISTRATION_CHECKER:
     description: |
       This is the service role supporting vehicle registration data providers.
       This role cannot create, modify or delete vehicle registrations.
-    identity_manager: VEHICLE_AUTHORITY
+    authority: VEHICLE_AUTHORITY
     examples:
       - "A vehicle registration data provider protects its endpoints with UTM uvin scopes."
       - "USS queries a vehicle data provider using its uvin scopes to check whethter a UVIN is registered."
@@ -78,7 +78,7 @@ CONFLICT_MANAGEMENT:
        This is the service role supporting USS Confict Management data providers.
        These data providers can be pull-based such as Grid Cell data, or a push-and-pull based
        such as NASA's Discovery Service.
-    identity_manager: USS Network
+    authority: USS Network
     examples:
        - "NASA's USS Discovery Service PUTs USSInstance data to USS-API endpoints protected by write.conflictmanagement scope."
        - "USS Discovery service protects its endpoints with read.conflictmanagement scope."
@@ -89,7 +89,7 @@ CONFLICT_MANAGEMENT:
 USS_BASIC:
     description: A USS. The UTM Authority assigns role after
        out-of-band vetting. Vetting includes some testing mechanism and liability assumptions TBD.
-    identity_manager: UTM_AUTHORITY
+    authority: UTM_AUTHORITY
     examples:
         - "USS announces its operation to another USS."
         - "USS queries Vehicle Registration server to check that a UVIN is registered."
@@ -110,7 +110,7 @@ USS_PUBLIC_SAFETY:
        USS_BASIC role. The UTM Authority assigns this role after out-of-band
        vetting, which includes some testing mechanism and liability
        assumptions TBD.
-    identity_manager: UTM_AUTHORITY
+    authority: UTM_AUTHORITY
     examples:
         - "A Public Safety USS queries other USSs to determine which USS is operating a particular vehicle."
         - "A Public Safety USS queries vehicle registration using its uvin scopes to learn the vehicle's owner."
@@ -125,7 +125,7 @@ USS_CONSTRAINT_MANAGER:
        USS_BASIC role. The UTM Authority assigns this role after out-of-band
        vetting, which includes some testing mechanism and liability
        assumptions TBD.
-    identity_manager: UTM_AUTHORITY
+    authority: UTM_AUTHORITY
     examples:
         - "A USS with Contraint Management role publishes an airspace constraint to the USS Network."
     scopes:

--- a/fimsauthz-api/utm-roles.yaml
+++ b/fimsauthz-api/utm-roles.yaml
@@ -8,7 +8,7 @@ UTM_AUTHORITY:
     description: |
       A small set of trusted users who manage identities of all core UTM
       components such as USSs.
-    identity_owner: itself
+    identity_manager: ANSP
     examples:
       - "UTM Authority vets USS1's additional capability for Public Service, and adds the PUBLIC_SAFETY role to USS1 in the master list."
       - "UTM Authority vets USS1, then adds an entry to master USS list and assigns the USS_BASIC role."
@@ -22,7 +22,7 @@ FIMS_ADMIN:
         Authentication (MFA) should be enforced users with this role,
         and the number of users with this role should be minimized.
         This role is typically associated with a User whose authorization is out of band WRT FIMS oauth.
-    identity_owner: UTM_AUTHORITY
+    identity_manager: UTM_AUTHORITY
     examples:
         - "An IT admin manages FIMS-AZ logfiles."
         - "An IT admin reads the master USS list to update FIMS-AZ's data table containing the USSs, their scopes and their credentials."
@@ -33,28 +33,28 @@ FIMS_SME:
         manages airspace constraints and other aeronautical data
         This user could be a client to the FIMS Ops server using a User Interface (rather than CLI).
         This role is typically associated with a user whose authorization is out of band WRT FIMS oauth.
-    identity_owner: ANSP
+    identity_manager: ANSP
     examples:
         - "An airspace Subject Matter Expert composes an airspace constraint and submits this constraint to FIMS_OPS."
 
 FIMS_AUTHZ:
     description: This is the service role supporting the FIMS Authorization server.
     This role cannot create, modify or delete UTM Identity data, rather access is read-only.
-    identity_owner: UTM_AUTHORITY
+    identity_manager: UTM_AUTHORITY
     examples:
         - "When FIMS AZ services the token endpoint, it reads a data table containing USS identities and their scopes."
 
 FIMS_OPS:
     description: This role manages the interface between the USS Network and
     the ANSP.  This role is assigned to the FIMS_OPS server.
-    identity_owner: UTM_AUTHORITY
+    identity_manager: UTM_AUTHORITY
     examples:
         - "FIMS_OPS is authorized to inject an airspace constraint to the USS Network."
     scopes:
         - utm.nasa.gov_write.constraint
 
 VEHICLE_AUTHORITY:
-    identity_owner: TBD; May be a set of trusted commercial entities
+    identity_manager: TBD; May be a set of trusted commercial entities
     description: |
       This role allows creation, modifcation and deletion of vehicle registrations.
       This role is typically associated with a user whose authentication and
@@ -67,40 +67,41 @@ VEHICLE_REGISTRATION_CHECKER:
     description: |
       This is the service role supporting vehicle registration data providers.
       This role cannot create, modify or delete vehicle registrations.
-    identity_owner: VEHICLE_AUTHORITY
+    identity_manager: VEHICLE_AUTHORITY
     examples:
       - "A vehicle registration data provider protects its endpoints with UTM uvin scopes."
       - "USS queries a vehicle data provider using its uvin scopes to check whethter a UVIN is registered."
       - "A Public Safety USS queries a vehicle data provider using its uvin scopes to learn the vehicle's owner."
 
-STRATEGIC_CM:
+CONFLICT_MANAGEMENT:
     description: |
-       This is the service role supporting USS Strategic Confict Management data providers.
+       This is the service role supporting USS Confict Management data providers.
        These data providers can be pull-based such as Grid Cell data, or a push-and-pull based
        such as NASA's Discovery Service.
-    identity_owner: USS Network
+    identity_manager: USS Network
     examples:
-       - "NASA's USS Discovery Service PUTs USSInstance data to USS endpoints protected by write.stategic_cm scope."
-       - "A Strategic CM data provider protects its endpoints with write.stategic_cm scope to authorize Grid Cell updates."
+       - "NASA's USS Discovery Service PUTs USSInstance data to USS-API endpoints protected by write.conflictmanagement scope."
+       - "USS Discovery service protects its endpoints with read.conflictmanagement scope."
+       - "The Grid Cell Conflict Management service protects its endpoints with read.conflictmanagement scope."
     scopes:
-       - utm.nasa.gov_write.stategic_cm
+       - utm.nasa.gov_write.conflictmanagement
 
 USS_BASIC:
     description: A USS. The UTM Authority assigns role after
-    out-of-band vetting. Vetting includes some testing mechanism and liability assumptions TBD.
-    identity_owner: UTM_AUTHORITY
+       out-of-band vetting. Vetting includes some testing mechanism and liability assumptions TBD.
+    identity_manager: UTM_AUTHORITY
     examples:
         - "USS announces its operation to another USS."
         - "USS queries Vehicle Registration server to check that a UVIN is registered."
         - "USS queries NASA's USS Discovery service to discover other USSs intersecting its coverage area."
         - "USS registers its coverage area with NASA's USS Discovery service."
-        - "USS writes to a Strategic CM service such as GridCell to announce new operations."
+        - "USS writes to a Conflict Management service such as GridCell to announce new operations."
     scopes:
         - utm.nasa.gov_write.operation
         - utm.nasa.gov_write.message
         - utm.nasa.gov_read.contraint
         - utm.nasa.gov_read_min.uvin
-        - utm.nasa.gov_write.stategic_cm
+        - utm.nasa.gov_write.conflictmanagement
 
 USS_PUBLIC_SAFETY:
     description: |
@@ -109,7 +110,7 @@ USS_PUBLIC_SAFETY:
        USS_BASIC role. The UTM Authority assigns this role after out-of-band
        vetting, which includes some testing mechanism and liability
        assumptions TBD.
-    identity_owner: UTM_AUTHORITY
+    identity_manager: UTM_AUTHORITY
     examples:
         - "A Public Safety USS queries other USSs to determine which USS is operating a particular vehicle."
         - "A Public Safety USS queries vehicle registration using its uvin scopes to learn the vehicle's owner."
@@ -124,7 +125,7 @@ USS_CONSTRAINT_MANAGER:
        USS_BASIC role. The UTM Authority assigns this role after out-of-band
        vetting, which includes some testing mechanism and liability
        assumptions TBD.
-    identity_owner: UTM_AUTHORITY
+    identity_manager: UTM_AUTHORITY
     examples:
         - "A USS with Contraint Management role publishes an airspace constraint to the USS Network."
     scopes:

--- a/fimsauthz-api/utm-roles.yml
+++ b/fimsauthz-api/utm-roles.yml
@@ -10,9 +10,8 @@ UTM_AUTHORITY:
       components such as USSs.
     identity_owner: itself
     examples:
-      - "UTM Authority vets USS1's additional capability for PublicService, and adds the PUBLIC_SAFETY role to USS1 in the master list."
+      - "UTM Authority vets USS1's additional capability for Public Service, and adds the PUBLIC_SAFETY role to USS1 in the master list."
       - "UTM Authority vets USS1, then adds an entry to master USS list and assigns the USS_BASIC role."
-
 
 FIMS_ADMIN:
     description: |
@@ -23,7 +22,6 @@ FIMS_ADMIN:
         Authentication (MFA) should be enforced users with this role,
         and the number of users with this role should be minimized.
         This role is typically associated with a User whose authorization is out of band WRT FIMS oauth.
-
     identity_owner: UTM_AUTHORITY
     examples:
         - "An IT admin manages FIMS-AZ logfiles."
@@ -31,27 +29,24 @@ FIMS_ADMIN:
 
 FIMS_SME:
     description: |
-        A user who is a FIMS Subject Matter Expert (SME) that
+        A role is assigned to user who is a FIMS Subject Matter Expert (SME) who
         manages airspace constraints and other aeronautical data
-        This user is typically a client to the FIMS Ops server, and often
-        works using a User Interface (rather than CLI).
-        This role is typically associated with a User whose authorization is out of band WRT FIMS oauth.
-
-    identity_owner: UTM_AUTHORITY
+        This user could be a client to the FIMS Ops server using a User Interface (rather than CLI).
+        This role is typically associated with a user whose authorization is out of band WRT FIMS oauth.
+    identity_owner: ANSP
     examples:
         - "An airspace Subject Matter Expert composes an airspace constraint and submits this constraint to FIMS_OPS."
 
 FIMS_AUTHZ:
-    description: This role is intrinsic to the FIMS Authorization server.
-    This role cannot create, modify or delete identities, rather it authenticates UTM principals.
-    This is an abstract role that is not associated with oauth scopes.
+    description: This is the service role supporting the FIMS Authorization server.
+    This role cannot create, modify or delete UTM Identity data, rather access is read-only.
     identity_owner: UTM_AUTHORITY
     examples:
         - "When FIMS AZ services the token endpoint, it reads a data table containing USS identities and their scopes."
 
 FIMS_OPS:
     description: This role manages the interface between the USS Network and
-    the ANSP.  This role is intrinsic to the FIMS_OPS server.
+    the ANSP.  This role is assigned to the FIMS_OPS server.
     identity_owner: UTM_AUTHORITY
     examples:
         - "FIMS_OPS is authorized to inject an airspace constraint to the USS Network."
@@ -61,22 +56,34 @@ FIMS_OPS:
 VEHICLE_AUTHORITY:
     identity_owner: TBD; May be a set of trusted commercial entities
     description: |
-      Enables a users who are Vehicle Subject Matter Experts
-      to manage vehicle registrations.
-      This role can create, modify and delete vehicle registrations.
-      Assigned to a small set of trusted entities by out-of-band processes tdb.
-      This is an abstract role that is not associated with oauth scopes.
+      This role allows creation, modifcation and deletion of vehicle registrations.
+      This role is typically associated with a user whose authentication and
+      authorization is out of band WRT FIMS oauth.
+      These users are small set of trusted vehicle subject matter experts who manage vehicle registrations.
     examples:
        - "A vehicle subject matter expert adds a new vehicle UVIN."
 
-VEHICLE_REGISTRATION:
-    description:
-      Checks vehicle registrations using read-only access to registration data.
+VEHICLE_REGISTRATION_CHECKER:
+    description: |
+      This is the service role supporting vehicle registration data providers.
       This role cannot create, modify or delete vehicle registrations.
-      This is an abstract role that is not associated with oauth scopes.
     identity_owner: VEHICLE_AUTHORITY
     examples:
-      - "A vehicle registration data provider protects its endpoints with these scopes."
+      - "A vehicle registration data provider protects its endpoints with UTM uvin scopes."
+      - "USS queries a vehicle data provider using its uvin scopes to check whethter a UVIN is registered."
+      - "A Public Safety USS queries a vehicle data provider using its uvin scopes to learn the vehicle's owner."
+
+STRATEGIC_CM:
+    description: |
+       This is the service role supporting USS Strategic Confict Management data providers.
+       These data providers can be pull-based such as Grid Cell data, or a push-and-pull based
+       such as NASA's Discovery Service.
+    identity_owner: USS Network
+    examples:
+       - "NASA's USS Discovery Service PUTs USSInstance data to USS endpoints protected by write.stategic_cm scope."
+       - "A Strategic CM data provider protects its endpoints with write.stategic_cm scope to authorize Grid Cell updates."
+    scopes:
+       - utm.nasa.gov_write.stategic_cm
 
 USS_BASIC:
     description: A USS. The UTM Authority assigns role after
@@ -84,10 +91,10 @@ USS_BASIC:
     identity_owner: UTM_AUTHORITY
     examples:
         - "USS announces its operation to another USS."
-        - "USS queries Vehicle Registration Checker to determine if a UVIN is registered."
+        - "USS queries Vehicle Registration server to check that a UVIN is registered."
         - "USS queries NASA's USS Discovery service to discover other USSs intersecting its coverage area."
         - "USS registers its coverage area with NASA's USS Discovery service."
-        - "USS writes to a pull-based Strategic CM service such as GridCell to announce new operations."
+        - "USS writes to a Strategic CM service such as GridCell to announce new operations."
     scopes:
         - utm.nasa.gov_write.operation
         - utm.nasa.gov_write.message
@@ -102,10 +109,10 @@ USS_PUBLIC_SAFETY:
        USS_BASIC role. The UTM Authority assigns this role after out-of-band
        vetting, which includes some testing mechanism and liability
        assumptions TBD.
-    identity_owner:
+    identity_owner: UTM_AUTHORITY
     examples:
-        - "A USS with the Public Safety role queries other USSs to determine which USS is operating a particular vehicle."
-        - "A USS with the Public Safety role queries vehicle registration to learn the vehicle's owner."
+        - "A Public Safety USS queries other USSs to determine which USS is operating a particular vehicle."
+        - "A Public Safety USS queries vehicle registration using its uvin scopes to learn the vehicle's owner."
     scopes:
         - utm.nasa.gov_write.publicsafety
         - utm.nasa.gov_read.uvin
@@ -122,17 +129,3 @@ USS_CONSTRAINT_MANAGER:
         - "A USS with Contraint Management role publishes an airspace constraint to the USS Network."
     scopes:
         - utm.nasa.gov_write.constraint
-
-STRATEGIC_CM:
-    description: |
-       This role grants access to USS Strategic Confict Management data.
-       The data provider can be pull-based such as Grid Cell data, or a push-and-pull based server
-       such as NASA's Discovery Service.
-       A pull-based data provider server would protect its endpoints using these scopes.
-       A push-based data provider would PUT data to endpoints protected by these scopes.
-    identity_owner: UTM_AUTHORITY
-    examples:
-       - "NASA's USS Discovery service announces a USS instance to other USSs by PUTing USSInstance data to other USSs callback"
-       - "A Strategic CM service protects its endpoints with these scopes to authroize USSs to update Grid Cells."
-    scopes:
-          - utm.nasa.gov_write.stategic_cm

--- a/fimsauthz-api/utm-roles.yml
+++ b/fimsauthz-api/utm-roles.yml
@@ -8,23 +8,25 @@ UTM_AUTHORITY:
     description: |
       A small set of trusted users who manage identities of all core UTM
       components such as USSs.
+      This is an abstract role that is not associated with oauth scopes.
 
 FIMS_ADMIN:
     description: |
-        (Alternative names... FIMS Elevated Privs)
         This role enables an IT admin to maintain FIMS, for example by managing
         databases and servers via command line interface (CLI).  This role
         should not, in general, allow reading FIMS business data as knowledge
         of FIMS data is usually not needed to get the job done. Multi-Factor
         Authentication (MFA) should be enforced users with this role,
         and the number of users with this role should be minimized.
+        This is an abstract role that is not associated with oauth scopes.
 
 FIMS_SME:
     description: |
         (Alternative name... FIMS Manager)
         A user who is a FIMS Subject Matter Expert (SME) that
         manages airspace constraints and other aeronautical data
-        This user is typically a client to the FIMS Ops server.
+        This user is typically a client to the FIMS Ops server, and often
+        works using a User Interface (rather than CLI).
     identity_owner: UTM_AUTHORITY
     scopes:
         - utm.nasa.gov_write.fimsadmin
@@ -54,6 +56,7 @@ VEHICLE_AUTHORITY:
       Assigned to a small set of trusted entities by out-of-band processes tdb.
       Enables a users who are Vehicle Subject Matter Experts
       to manage vehicle registrations.
+      This is an abstract role that is not associated with oauth scopes.
 
 VEHICLE_REGISTRATION_CHECKER:
     description:
@@ -83,6 +86,10 @@ USS_PUBLIC_SAFETY:
        assumptions TBD.
     identity_owner: UTM_AUTHORITY
     scopes:
+        - utm.nasa.gov_write.operation
+        - utm.nasa.gov_write.message
+        - utm.nasa.gov_read.contraint
+        - utm.nasa.gov_read_min.uvin
         - utm.nasa.gov_write.publicsafety
         - utm.nasa.gov_read.uvin
 
@@ -93,4 +100,8 @@ USS_CONSTRAINT_MANAGER:
        that has the USS_BASIC role.
     identity_owner: UTM_AUTHORITY
     scopes:
+        - utm.nasa.gov_write.operation
+        - utm.nasa.gov_write.message
+        - utm.nasa.gov_read.contraint
+        - utm.nasa.gov_read_min.uvin
         - utm.nasa.gov_write.constraint

--- a/fimsauthz-api/utm-roles.yml
+++ b/fimsauthz-api/utm-roles.yml
@@ -1,0 +1,96 @@
+# UTM roles and, when applicatble, their scopes.
+#   This is the master data for the Role and Scopes for the
+#   FIMS Authorization Server.
+#   Its schema is defined as a domain in swgger spec.
+#
+
+UTM_AUTHORITY:
+    description: |
+      A small set of trusted users who manage identities of all core UTM
+      components such as USSs.
+
+FIMS_ADMIN:
+    description: |
+        (Alternative names... FIMS Elevated Privs)
+        This role enables an IT admin to maintain FIMS, for example by managing
+        databases and servers via command line interface (CLI).  This role
+        should not, in general, allow reading FIMS business data as knowledge
+        of FIMS data is usually not needed to get the job done. Multi-Factor
+        Authentication (MFA) should be enforced users with this role,
+        and the number of users with this role should be minimized.
+
+FIMS_SME:
+    description: |
+        (Alternative name... FIMS Manager)
+        A user who is a FIMS Subject Matter Expert (SME) that
+        manages airspace constraints and other aeronautical data
+        This user is typically a client to the FIMS Ops server.
+    identity_owner: UTM_AUTHORITY
+    scopes:
+        - utm.nasa.gov_write.fimsadmin
+
+FIMS_AUTHZ:
+    description: This role is intrinsic to the FIMS Authorization server.
+    This role cannot create, modify or delete identities, rather it
+    authenticates UTM principals.
+    identity_owner: UTM_AUTHORITY
+    scopes:
+      - utm.nasa.gov_read.fimsadmin
+
+FIMS_OPS:
+    description: This role manages the interface between the USS Network and
+    the ANSP.  This role is intrinsic to the FIMS_OPS server.
+    identity_owner: UTM_AUTHORITY
+    scopes:
+        - utm.nasa.gov_write.operation
+        - utm.nasa.gov_write.message
+        - utm.nasa.gov_write.constraint
+        - utm.nasa.gov_read.fimsadmin
+
+VEHICLE_AUTHORITY:
+    identity_owner: TBD; May be a set of trusted commercial entities
+    description: |
+      This role can create, modify and delete vehicle registrations.
+      Assigned to a small set of trusted entities by out-of-band processes tdb.
+      Enables a users who are Vehicle Subject Matter Experts
+      to manage vehicle registrations.
+
+VEHICLE_REGISTRATION_CHECKER:
+    description:
+      Checks vehicle registrations using read-only access to registration data.
+      This role cannot create, modify or delete vehicle registrations, and
+      has access to a redacted data set.
+    identity_owner: VEHICLE_AUTHORITY
+    scopes:
+      - utm.nasa.gov_read.uvin
+      - utm.nasa.gov_read_min.uvin
+
+USS_BASIC:
+    description: A USS
+    identity_owner: UTM_AUTHORITY
+    scopes:
+        - utm.nasa.gov_write.operation
+        - utm.nasa.gov_write.message
+        - utm.nasa.gov_read.contraint
+        - utm.nasa.gov_read_min.uvin
+
+USS_PUBLIC_SAFETY:
+    description: |
+       A USS with the capability to support public safety entities, by supporting
+       queries. This role can be assigned only to a principal that has the
+       USS_BASIC role. The UTM Authority assigns role after out-of-band
+       vetting, which the vetting includes some testing mechanism and liability
+       assumptions TBD.
+    identity_owner: UTM_AUTHORITY
+    scopes:
+        - utm.nasa.gov_write.publicsafety
+        - utm.nasa.gov_read.uvin
+
+USS_CONSTRAINT_MANAGER:
+    description: |
+       A USS with the capabiity to support manage airspace constraints and
+       other aeronautical data. This role can be assigned only to a principal
+       that has the USS_BASIC role.
+    identity_owner: UTM_AUTHORITY
+    scopes:
+        - utm.nasa.gov_write.constraint

--- a/fimsauthz-api/utm-roles.yml
+++ b/fimsauthz-api/utm-roles.yml
@@ -8,7 +8,6 @@ UTM_AUTHORITY:
     description: |
       A small set of trusted users who manage identities of all core UTM
       components such as USSs.
-      This is an abstract role that is not associated with oauth scopes.
     identity_owner: itself
     examples:
       - "UTM Authority vets USS1's additional capability for PublicService, and adds the PUBLIC_SAFETY role to USS1 in the master list."
@@ -23,7 +22,8 @@ FIMS_ADMIN:
         of FIMS data is usually not needed to get the job done. Multi-Factor
         Authentication (MFA) should be enforced users with this role,
         and the number of users with this role should be minimized.
-        This is an abstract role that is not associated with oauth scopes.
+        This role is typically associated with a User whose authorization is out of band WRT FIMS oauth.
+
     identity_owner: UTM_AUTHORITY
     examples:
         - "An IT admin manages FIMS-AZ logfiles."
@@ -35,36 +35,28 @@ FIMS_SME:
         manages airspace constraints and other aeronautical data
         This user is typically a client to the FIMS Ops server, and often
         works using a User Interface (rather than CLI).
+        This role is typically associated with a User whose authorization is out of band WRT FIMS oauth.
+
     identity_owner: UTM_AUTHORITY
     examples:
         - "An airspace Subject Matter Expert composes an airspace constraint and submits this constraint to FIMS_OPS."
-    scopes:
-        - utm.nasa.gov_write.constraint
-        - utm.nasa.gov_read.fimsadmin
-        - utm.nasa.gov_write.operation
-        - utm.nasa.gov_write.message
 
 FIMS_AUTHZ:
     description: This role is intrinsic to the FIMS Authorization server.
-    This role cannot create, modify or delete identities, rather it
-    authenticates UTM principals.
+    This role cannot create, modify or delete identities, rather it authenticates UTM principals.
+    This is an abstract role that is not associated with oauth scopes.
     identity_owner: UTM_AUTHORITY
     examples:
-        - "When FIMS AZ services the token endpoint, it reads the data table containing the USSs and their scopes."
-    scopes:
-       - utm.nasa.gov_read.fimsadmin
+        - "When FIMS AZ services the token endpoint, it reads a data table containing USS identities and their scopes."
 
 FIMS_OPS:
     description: This role manages the interface between the USS Network and
     the ANSP.  This role is intrinsic to the FIMS_OPS server.
     identity_owner: UTM_AUTHORITY
     examples:
-        - "FIMS_OPS injects an airspace constraint to the USS Network."
+        - "FIMS_OPS is authorized to inject an airspace constraint to the USS Network."
     scopes:
-        - utm.nasa.gov_read.operation
-        - utm.nasa.gov_read.message
         - utm.nasa.gov_write.constraint
-        - utm.nasa.gov_read.fimsadmin
 
 VEHICLE_AUTHORITY:
     identity_owner: TBD; May be a set of trusted commercial entities
@@ -77,14 +69,14 @@ VEHICLE_AUTHORITY:
     examples:
        - "A vehicle subject matter expert adds a new vehicle UVIN."
 
-VEHICLE_REGISTRATION_CHECKER:
+VEHICLE_REGISTRATION:
     description:
       Checks vehicle registrations using read-only access to registration data.
       This role cannot create, modify or delete vehicle registrations.
       This is an abstract role that is not associated with oauth scopes.
     identity_owner: VEHICLE_AUTHORITY
     examples:
-      - "A Vehicle registration checker server protects its GET endpoints with the utm.nasa.gov_read_min.uvin scope. A USS with that scope may get data from that endpoint."
+      - "A vehicle registration data provider protects its endpoints with these scopes."
 
 USS_BASIC:
     description: A USS. The UTM Authority assigns role after
@@ -105,24 +97,25 @@ USS_BASIC:
 
 USS_PUBLIC_SAFETY:
     description: |
-       A USS with the capability to support public safety entities, by supporting
-       queries. This role can be assigned only to a principal that has the
-       USS_BASIC role. The UTM Authority assigns role after out-of-band
-       vetting, which the vetting includes some testing mechanism and liability
+       A USS with the capability to support public safety queries.
+       This role can be assigned only to a USS that has the
+       USS_BASIC role. The UTM Authority assigns this role after out-of-band
+       vetting, which includes some testing mechanism and liability
        assumptions TBD.
     identity_owner:
     examples:
         - "A USS with the Public Safety role queries other USSs to determine which USS is operating a particular vehicle."
+        - "A USS with the Public Safety role queries vehicle registration to learn the vehicle's owner."
     scopes:
         - utm.nasa.gov_write.publicsafety
         - utm.nasa.gov_read.uvin
 
 USS_CONSTRAINT_MANAGER:
     description: |
-       A USS with the capabiity to support manage airspace constraints and
-       other aeronautical data. This role can be assigned only to a principal
-       that has the USS_BASIC role. The UTM Authority assigns role after out-of-band
-       vetting, which the vetting includes some testing mechanism and liability
+       A USS with this role can publish airspace constraints and
+       other aeronautical data. This role can be assigned only to a USS that has the
+       USS_BASIC role. The UTM Authority assigns this role after out-of-band
+       vetting, which includes some testing mechanism and liability
        assumptions TBD.
     identity_owner: UTM_AUTHORITY
     examples:
@@ -132,12 +125,14 @@ USS_CONSTRAINT_MANAGER:
 
 STRATEGIC_CM:
     description: |
-       This role supports USS Strategic Confict Management. This role can be a
-       pull-based Data Provider such as Grid Cell, or a push-and-pull based server
+       This role grants access to USS Strategic Confict Management data.
+       The data provider can be pull-based such as Grid Cell data, or a push-and-pull based server
        such as NASA's Discovery Service.
+       A pull-based data provider server would protect its endpoints using these scopes.
+       A push-based data provider would PUT data to endpoints protected by these scopes.
     identity_owner: UTM_AUTHORITY
     examples:
        - "NASA's USS Discovery service announces a USS instance to other USSs by PUTing USSInstance data to other USSs callback"
-       - "A Strategic CM service protects its endpoints with utm.nasa.gov_write.stategic_cm to support USSs updating Grid Cells."
+       - "A Strategic CM service protects its endpoints with these scopes to authroize USSs to update Grid Cells."
     scopes:
           - utm.nasa.gov_write.stategic_cm

--- a/fimsauthz-api/utm-roles.yml
+++ b/fimsauthz-api/utm-roles.yml
@@ -9,73 +9,99 @@ UTM_AUTHORITY:
       A small set of trusted users who manage identities of all core UTM
       components such as USSs.
       This is an abstract role that is not associated with oauth scopes.
+    identity_owner: itself
+    examples:
+      - "UTM Authority vets USS1's additional capability for PublicService, and adds the PUBLIC_SAFETY role to USS1 in the master list."
+      - "UTM Authority vets USS1, then adds an entry to master USS list and assigns the USS_BASIC role."
+
 
 FIMS_ADMIN:
     description: |
         This role enables an IT admin to maintain FIMS, for example by managing
-        databases and servers via command line interface (CLI).  This role
+        logfiles and servers via command line interface (CLI).  This role
         should not, in general, allow reading FIMS business data as knowledge
         of FIMS data is usually not needed to get the job done. Multi-Factor
         Authentication (MFA) should be enforced users with this role,
         and the number of users with this role should be minimized.
         This is an abstract role that is not associated with oauth scopes.
+    identity_owner: UTM_AUTHORITY
+    examples:
+        - "An IT admin manages FIMS-AZ logfiles."
+        - "An IT admin reads the master USS list to update FIMS-AZ's data table containing the USSs, their scopes and their credentials."
 
 FIMS_SME:
     description: |
-        (Alternative name... FIMS Manager)
         A user who is a FIMS Subject Matter Expert (SME) that
         manages airspace constraints and other aeronautical data
         This user is typically a client to the FIMS Ops server, and often
         works using a User Interface (rather than CLI).
     identity_owner: UTM_AUTHORITY
+    examples:
+        - "An airspace Subject Matter Expert composes an airspace constraint and submits this constraint to FIMS_OPS."
     scopes:
-        - utm.nasa.gov_write.fimsadmin
+        - utm.nasa.gov_write.constraint
+        - utm.nasa.gov_read.fimsadmin
+        - utm.nasa.gov_write.operation
+        - utm.nasa.gov_write.message
 
 FIMS_AUTHZ:
     description: This role is intrinsic to the FIMS Authorization server.
     This role cannot create, modify or delete identities, rather it
     authenticates UTM principals.
     identity_owner: UTM_AUTHORITY
+    examples:
+        - "When FIMS AZ services the token endpoint, it reads the data table containing the USSs and their scopes."
     scopes:
-      - utm.nasa.gov_read.fimsadmin
+       - utm.nasa.gov_read.fimsadmin
 
 FIMS_OPS:
     description: This role manages the interface between the USS Network and
     the ANSP.  This role is intrinsic to the FIMS_OPS server.
     identity_owner: UTM_AUTHORITY
+    examples:
+        - "FIMS_OPS injects an airspace constraint to the USS Network."
     scopes:
-        - utm.nasa.gov_write.operation
-        - utm.nasa.gov_write.message
+        - utm.nasa.gov_read.operation
+        - utm.nasa.gov_read.message
         - utm.nasa.gov_write.constraint
         - utm.nasa.gov_read.fimsadmin
 
 VEHICLE_AUTHORITY:
     identity_owner: TBD; May be a set of trusted commercial entities
     description: |
-      This role can create, modify and delete vehicle registrations.
-      Assigned to a small set of trusted entities by out-of-band processes tdb.
       Enables a users who are Vehicle Subject Matter Experts
       to manage vehicle registrations.
+      This role can create, modify and delete vehicle registrations.
+      Assigned to a small set of trusted entities by out-of-band processes tdb.
       This is an abstract role that is not associated with oauth scopes.
+    examples:
+       - "A vehicle subject matter expert adds a new vehicle UVIN."
 
 VEHICLE_REGISTRATION_CHECKER:
     description:
       Checks vehicle registrations using read-only access to registration data.
-      This role cannot create, modify or delete vehicle registrations, and
-      has access to a redacted data set.
+      This role cannot create, modify or delete vehicle registrations.
+      This is an abstract role that is not associated with oauth scopes.
     identity_owner: VEHICLE_AUTHORITY
-    scopes:
-      - utm.nasa.gov_read.uvin
-      - utm.nasa.gov_read_min.uvin
+    examples:
+      - "A Vehicle registration checker server protects its GET endpoints with the utm.nasa.gov_read_min.uvin scope. A USS with that scope may get data from that endpoint."
 
 USS_BASIC:
-    description: A USS
+    description: A USS. The UTM Authority assigns role after
+    out-of-band vetting. Vetting includes some testing mechanism and liability assumptions TBD.
     identity_owner: UTM_AUTHORITY
+    examples:
+        - "USS announces its operation to another USS."
+        - "USS queries Vehicle Registration Checker to determine if a UVIN is registered."
+        - "USS queries NASA's USS Discovery service to discover other USSs intersecting its coverage area."
+        - "USS registers its coverage area with NASA's USS Discovery service."
+        - "USS writes to a pull-based Strategic CM service such as GridCell to announce new operations."
     scopes:
         - utm.nasa.gov_write.operation
         - utm.nasa.gov_write.message
         - utm.nasa.gov_read.contraint
         - utm.nasa.gov_read_min.uvin
+        - utm.nasa.gov_write.stategic_cm
 
 USS_PUBLIC_SAFETY:
     description: |
@@ -84,12 +110,10 @@ USS_PUBLIC_SAFETY:
        USS_BASIC role. The UTM Authority assigns role after out-of-band
        vetting, which the vetting includes some testing mechanism and liability
        assumptions TBD.
-    identity_owner: UTM_AUTHORITY
+    identity_owner:
+    examples:
+        - "A USS with the Public Safety role queries other USSs to determine which USS is operating a particular vehicle."
     scopes:
-        - utm.nasa.gov_write.operation
-        - utm.nasa.gov_write.message
-        - utm.nasa.gov_read.contraint
-        - utm.nasa.gov_read_min.uvin
         - utm.nasa.gov_write.publicsafety
         - utm.nasa.gov_read.uvin
 
@@ -97,11 +121,23 @@ USS_CONSTRAINT_MANAGER:
     description: |
        A USS with the capabiity to support manage airspace constraints and
        other aeronautical data. This role can be assigned only to a principal
-       that has the USS_BASIC role.
+       that has the USS_BASIC role. The UTM Authority assigns role after out-of-band
+       vetting, which the vetting includes some testing mechanism and liability
+       assumptions TBD.
     identity_owner: UTM_AUTHORITY
+    examples:
+        - "A USS with Contraint Management role publishes an airspace constraint to the USS Network."
     scopes:
-        - utm.nasa.gov_write.operation
-        - utm.nasa.gov_write.message
-        - utm.nasa.gov_read.contraint
-        - utm.nasa.gov_read_min.uvin
         - utm.nasa.gov_write.constraint
+
+STRATEGIC_CM:
+    description: |
+       This role supports USS Strategic Confict Management. This role can be a
+       pull-based Data Provider such as Grid Cell, or a push-and-pull based server
+       such as NASA's Discovery Service.
+    identity_owner: UTM_AUTHORITY
+    examples:
+       - "NASA's USS Discovery service announces a USS instance to other USSs by PUTing USSInstance data to other USSs callback"
+       - "A Strategic CM service protects its endpoints with utm.nasa.gov_write.stategic_cm to support USSs updating Grid Cells."
+    scopes:
+          - utm.nasa.gov_write.stategic_cm

--- a/public-safety-uss/swagger.yaml
+++ b/public-safety-uss/swagger.yaml
@@ -43,15 +43,20 @@ schemes:
   - https
 
 securityDefinitions:
-  basicAuth:
-    type: basic
-security:
-    - basicAuth: []
+  pubsafe_oauth:
+    type: oauth2
+    authorizationUrl: 'https://utm.defined.host/oauth/token'
+    flow: implicit
+    scopes:
+      'utm.nasa.gov_read_publicsafety': "retrieve public safety data, for example, a Public Safety USS retrieves data."
+      'utm.nasa.gov_read_uvin': "retrieve uvin registration data, for example, a USS checks that a vehicle is registered."
+      'utm.nasa.gov_write.uvin': "Write uvin data, for example, a Vehicle Authority enters new data."
+
 
 paths:
   /uas/{uvin}:
     get:
-      description: Returns information on vehicle with the given uvin. 
+      description: Returns information on vehicle with the given uvin.
       parameters:
         - in: path
           name: "uvin"
@@ -99,7 +104,7 @@ paths:
           schema:
             $ref: >-
               https://raw.githubusercontent.com/nasa/utm-apis/master/utm-domains/utm-domain-commons.yaml#/definitions/UTMRestResponse
-  /uas:        
+  /uas:
     get:
       description: Returns vehicle information when a partial uvin or an faa_number is supplied. Atleast one parameter is required.
       parameters:
@@ -109,7 +114,7 @@ paths:
           maximum: 36.0
           minimum: 6
           type: "string"
-        - name: "faa_number"    
+        - name: "faa_number"
           in: "query"
           description: "Full faa_number."
           maximum: 10.0
@@ -128,7 +133,7 @@ paths:
           type: "number"
           maximum: 180.0
           minimum: -180.0
-          format: "double"  
+          format: "double"
       responses:
         200:
           description: "Successfully returns matched uvins and its associated operator information"
@@ -137,7 +142,7 @@ paths:
             items:
               $ref: >-
                  https://raw.githubusercontent.com/nasa/utm-apis/master/utm-domains/utm-domain-commons.yaml#/definitions/VehicleOperationData
-          
+
         401:
           description: "Unauthorized"
           schema:

--- a/uss-api/swagger.yaml
+++ b/uss-api/swagger.yaml
@@ -55,6 +55,9 @@ paths:
       tags:
         - A. Required Endpoints
       summary: Allow constraints to be submitted from authorized entities.
+      security:
+        - ussapi_security:
+            - utm.nasa.gov_write.constraint
       consumes:
         - application/json
       parameters:
@@ -88,16 +91,17 @@ paths:
           schema:
             $ref: >-
               https://raw.githubusercontent.com/nasa/utm-apis/master/utm-domains/utm-domain-commons.yaml#/definitions/UTMRestResponse
-      security:
-        - ussapi_security:
-            - utm.nasa.gov_write.constraint
-            - utm.nasa.gov_all.all
+
+
   '/utm_messages/{message_id}':
     put:
       tags:
         - A. Required Endpoints
       summary: Allow other authorized entities to send a message to this USS.
       description: Allows another USS or FIMS to POST a message to this USS.
+      security:
+        - ussapi_security:
+            - utm.nasa.gov_write.message
       consumes:
         - application/json
       parameters:
@@ -131,9 +135,7 @@ paths:
           schema:
             $ref: >-
               https://raw.githubusercontent.com/nasa/utm-apis/master/utm-domains/utm-domain-commons.yaml#/definitions/UTMRestResponse
-      security:
-        - ussapi_security:
-            - utm.nasa.gov_write.message
+
   '/uss/{uss_instance_id}':
     put:
       tags:
@@ -144,6 +146,9 @@ paths:
         receiving messages about the USS Network from the USS Discovery
         Service.  For example, when a new USS Instance is registered, that
         announcement would come to this endpoint.
+      security:
+        - ussapi_security:
+            - utm.nasa.gov_write.operation
       consumes:
         - application/json
       parameters:
@@ -177,6 +182,7 @@ paths:
           schema:
             $ref: >-
               https://raw.githubusercontent.com/nasa/utm-apis/master/utm-domains/utm-domain-commons.yaml#/definitions/UTMRestResponse
+
   '/negotiations/{message_id}':
     put:
       tags:
@@ -187,6 +193,9 @@ paths:
         alteration in an existing operation managed by the receiving USS.  The
         requesting USS supplies a GUFI that references the operation that may be
         altered if the request is granted by the receiving USS.
+      security:
+        - ussapi_security:
+            - utm.nasa.gov_write.message
       consumes:
         - application/json
       produces:
@@ -222,9 +231,7 @@ paths:
           schema:
             $ref: >-
               https://raw.githubusercontent.com/nasa/utm-apis/master/utm-domains/utm-domain-commons.yaml#/definitions/UTMRestResponse
-      security:
-        - ussapi_security:
-            - utm.nasa.gov_write.message
+
   '/positions/{position_id}':
     put:
       tags:
@@ -233,6 +240,9 @@ paths:
       description: >-
         Providing position reports to others may allow other USSs to anticipate
         events.  The USS managing the operation has created the position ID.
+      security:
+        - ussapi_security:
+            - utm.nasa.gov_write.operation
       consumes:
         - application/json
       produces:
@@ -273,6 +283,9 @@ paths:
         - A. Required Endpoints
       summary: Request information regarding Operations
       description: Allows querying for Operation data.
+      security:
+        - ussapi_security:
+            - utm.nasa.gov_read.operation
       produces:
         - application/json
       parameters:
@@ -346,7 +359,6 @@ paths:
             that interesect the 2D circle defined by distance and
             reference_point.  When distance it excluded and reference_point is
             included, use default value (300ft) for distance.
-
             Described as a GeoJSON position.  The value is equivalent to what
             would be seen in the "coordinates" field for a GeoJSON Point
             object.  See https://tools.ietf.org/html/rfc7946#section-3.1.1 for
@@ -354,7 +366,6 @@ paths:
             37.414371] (URL safe:
             reference_point%3D%5B-122.056364%2C%2037.414371%5D). As per GeoJSON
             spec, this is long-lat format in the WGS84 reference system.
-
             MUST NOT include a third coordinate element, strictly 2D.
           type: string
           format: geojson-position
@@ -418,15 +429,16 @@ paths:
           schema:
             $ref: >-
               https://raw.githubusercontent.com/nasa/utm-apis/master/utm-domains/utm-domain-commons.yaml#/definitions/UTMRestResponse
-      security:
-        - ussapi_security:
-            - utm.nasa.gov_read.operation
+
   '/operations/{gufi}':
     get:
       tags:
         - A. Required Endpoints
       summary: Retrieve an operation by GUFI.
       description: Retrieve an operation by GUFI.
+      security:
+        - ussapi_security:
+            - utm.nasa.gov_read.operation
       produces:
         - application/json
       parameters:
@@ -453,9 +465,7 @@ paths:
           schema:
             $ref: >-
               https://raw.githubusercontent.com/nasa/utm-apis/master/utm-domains/utm-domain-commons.yaml#/definitions/UTMRestResponse
-      security:
-        - ussapi_security:
-            - utm.nasa.gov_read.operation
+
     put:
       tags:
         - A. Required Endpoints
@@ -463,6 +473,9 @@ paths:
       description: >-
         Announce an Operation to another USS, either initial Operation or an
         update to the Operation. The Operation's owner creates the ID.
+      security:
+        - ussapi_security:
+            - utm.nasa.gov_write.operation
       consumes:
         - application/json
       produces:
@@ -511,10 +524,7 @@ paths:
           schema:
             $ref: >-
               https://raw.githubusercontent.com/nasa/utm-apis/master/utm-domains/utm-domain-commons.yaml#/definitions/UTMRestResponse
-      security:
-        - ussapi_security:
-            - utm.nasa.gov_write.operation
-            - utm.nasa.gov_write.publicsafety
+
 securityDefinitions:
   ussapi_security:
     type: oauth2

--- a/uss-api/swagger.yaml
+++ b/uss-api/swagger.yaml
@@ -46,9 +46,6 @@ basePath: /uss
 schemes:
   - https
 
-security:
-  - ussapi_security:
-      - utm.nasa.gov_read.min_data
 paths:
   '/constraints/{message_id}':
     put:

--- a/uss-discovery-api/swagger.yaml
+++ b/uss-discovery-api/swagger.yaml
@@ -55,8 +55,8 @@ securityDefinitions:
     tokenUrl: 'https://thisserver.com/oauth/token'
     flow: application
     scopes:
-      'utm.nasa.gov_read.stategic_cm':  Subject can read strategic conflict management data.
-      'utm.nasa.gov_write.stategic_cm':  Subject can read and write strategic conflict management data.
+      'utm.nasa.gov_read.conflictmanagement':  Subject can read conflict management data.
+      'utm.nasa.gov_write.conflictmanagement':  Subject can read and write conflict management data.
 
 paths:
   /uss:
@@ -227,7 +227,7 @@ paths:
       description: Allows for querying for USS Instances.
       security:
         - uss_discovery_security:
-            - utm.nasa.gov_read.stategic_cm
+            - utm.nasa.gov_read.conflictmanagement
       produces:
         - application/json
       parameters:
@@ -267,7 +267,7 @@ paths:
         - application/json
       security:
         - uss_discovery_security:
-            - utm.nasa.gov_write.stategic_cm
+            - utm.nasa.gov_write.conflictmanagement
       parameters:
         - name: id
           in: path

--- a/uss-discovery-api/swagger.yaml
+++ b/uss-discovery-api/swagger.yaml
@@ -55,11 +55,9 @@ securityDefinitions:
     tokenUrl: 'https://thisserver.com/oauth/token'
     flow: application
     scopes:
-      utm.nasa.gov_read.sdsp: read all USS Discovery data
-      utm.nasa.gov_write.sdsp: create and modify USS Discovery data that you own
-security:
-  - uss_discovery_security:
-      - utm.nasa.gov_read.sdsp
+      'utm.nasa.gov_read.stategic_cm':  Subject can read strategic conflict management data.
+      'utm.nasa.gov_write.stategic_cm':  Subject can read and write strategic conflict management data.
+
 paths:
   /uss:
     get:
@@ -67,7 +65,6 @@ paths:
         - A. Required Endpoints
       summary: Request information regarding USS instances
       description: Allows for querying for USS instances.
-      security: []
       consumes:
         - application/json
       produces:
@@ -228,7 +225,9 @@ paths:
         - A. Required Endpoints
       summary: Request information regarding a single USS Instance
       description: Allows for querying for USS Instances.
-      security: []
+      security:
+        - uss_discovery_security:
+            - utm.nasa.gov_read.stategic_cm
       produces:
         - application/json
       parameters:
@@ -268,7 +267,7 @@ paths:
         - application/json
       security:
         - uss_discovery_security:
-            - utm.nasa.gov_write.sdsp
+            - utm.nasa.gov_write.stategic_cm
       parameters:
         - name: id
           in: path

--- a/vehicle/swagger.yaml
+++ b/vehicle/swagger.yaml
@@ -48,10 +48,9 @@ securityDefinitions:
     authorizationUrl: 'https://utm.defined.host/oauth/token'
     flow: implicit
     scopes:
-      'utm.nasa.gov_read_min.uvin': "retrieve redacted uvin data, for example, a USS checks registration"
-      'utm.nasa.gov_read_uvin': "retrieve uvin data, for example, a Public Safety USS retrieves data."
+      'utm.nasa.gov_read_publicsafety': "retrieve public safety data, for example, a Public Safety USS retrieves data."
+      'utm.nasa.gov_read_uvin': "retrieve uvin registration data, for example, a USS checks that a vehicle is registered."
       'utm.nasa.gov_write.uvin': "Write uvin data, for example, a Vehicle Authority enters new data."
-
 
 paths:
   /uvins/{uvin}:
@@ -63,7 +62,7 @@ paths:
         the database, an empty array is returned also with a  200 HTTP code.
       security:
         - vehicle_oauth:
-            - utm.nasa.gov_read_min.uvin
+            - utm.nasa.gov_read_publicsafety
             - utm.nasa.gov_read_uvin
       parameters:
         - in: path
@@ -162,10 +161,10 @@ paths:
     get:
       description: >
         Returns information on vehicle owner, for example, a Public Safety
-          USS gets owner contact info for a vehicle
+          USS gets vehicle owner's contact data.
       security:
         - vehicle_oauth:
-            - 'utm.nasa.gov_read_min.uvin'
+            - 'utm.nasa.gov_read_publicsafety'
       parameters:
         - in: path
           name: "uvin"


### PR DESCRIPTION
utm-role.yaml is now in public utm-apis repo (under AZ folder).   This is the input to automated CI/CD.

At top of FimsAz swagger API spec is complete list of roles.

After 'description' of each endpoint definition is where the endpoint's scopes are defined. 

At top of each swaggerAPI spec is declaration of all roles this API uses (swagger validator requires this declaration.)

I will attempt to modify Confluence FIMS A & A now, since PR is hard to see big picture