### PR TITLE
Bump version

### DIFF
--- a/fims-api/swagger.yaml
+++ b/fims-api/swagger.yaml
@@ -4,7 +4,7 @@ info:
     This API describes the RESTful interface from a UAS Service Supplier (USS)
     to FIMS.
 
-  version: "v3"
+  version: "v4"
   title: "UTM Research Platform, FIMS-USS Interface"
   contact:
     name: NASA Ames Research Center, Aviation Systems Division

--- a/fimsauthz-api/swagger.yaml
+++ b/fimsauthz-api/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: "v3"
+  version: "v4"
   title: Flight Information Management System (FIMS) Authorization (Authz) Server
   description: >
     FIMS_Authz provides authorization services for FIMS and USS stakeholders within UTM.

--- a/nuss-operator-api/swagger.yaml
+++ b/nuss-operator-api/swagger.yaml
@@ -1542,21 +1542,6 @@ paths:
         410:
           description: "WRONG_PROTOCOL - A RESTful call was made to this endpoint\
             \ but this is not a REST endpoint."
-  /uss/stream/positions:
-    get:
-      tags:
-      - "Subscription Points"
-      summary: "Receive position updates"
-      description: "The connection URL is wss://{host}/uss/stream/position\n"
-      parameters:
-      - name: "gufi"
-        in: "query"
-        description: "GUFI of the operation whose position needs to be streamed"
-        required: false
-      responses:
-        410:
-          description: "WRONG_PROTOCOL - A RESTful call was made to this endpoint\
-            \ but this is not a REST endpoint."
   /surveillance_messages:
     get:
       tags:

--- a/nuss-operator-api/swagger.yaml
+++ b/nuss-operator-api/swagger.yaml
@@ -2,7 +2,7 @@
 swagger: "2.0"
 info:
   description: "RestAPI and Message definitions from USS-nasa to UAS Operator Interface"
-  version: "v2"
+  version: "v4"
   title: "USS-nasa to UAS Operator Interface"
 host: "tmiserver.arc.nasa.gov"
 basePath: "/uss"
@@ -423,7 +423,6 @@ paths:
       tags:
       - "Positions, Constraints, UReps"
       summary: "getConstraints"
-      operationId: "getConstraintsUsingGET"
       consumes:
       - "application/json"
       produces:

--- a/public-safety-uss/swagger.yaml
+++ b/public-safety-uss/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 'v1'
+  version: 'v4'
   title: Public Safety USS
   description: A USS with the Public Safety role implements this API in addition to the base USS API.
   contact:
@@ -51,7 +51,7 @@ security:
 paths:
   /uas/{uvin}:
     get:
-      description: Returns information on vehicle with the given uvin. 
+      description: Returns information on vehicle with the given uvin.
       parameters:
         - in: path
           name: "uvin"
@@ -99,7 +99,7 @@ paths:
           schema:
             $ref: >-
               https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/UTMRestResponse
-  /uas:        
+  /uas:
     get:
       description: Returns vehicle information when a partial uvin or an faa_number is supplied. Atleast one parameter is required.
       parameters:
@@ -109,7 +109,7 @@ paths:
           maximum: 36.0
           minimum: 6
           type: "string"
-        - name: "faa_number"    
+        - name: "faa_number"
           in: "query"
           description: "Full faa_number."
           maximum: 10.0
@@ -128,7 +128,7 @@ paths:
           type: "number"
           maximum: 180.0
           minimum: -180.0
-          format: "double"  
+          format: "double"
       responses:
         200:
           description: "Successfully returns matched uvins and its associated operator information"
@@ -137,7 +137,7 @@ paths:
             items:
               $ref: >-
                  https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/VehicleOperationData
-          
+
         401:
           description: "Unauthorized"
           schema:

--- a/uss-api/swagger.yaml
+++ b/uss-api/swagger.yaml
@@ -4,7 +4,7 @@ info:
     This API describes the minimum interface that a USS must implement to  be
     part of the USS Network.  This API allows for communication of data  between
     USS Instances and from FIMS to a USS regarding new USS Instances.
-  version: v3
+  version: v4
   title: USS Required API
   termsOfService: >
 

--- a/uss-discovery-api/swagger.yaml
+++ b/uss-discovery-api/swagger.yaml
@@ -5,7 +5,7 @@ info:
     the UTM System.  This service allows for authenticated USS operators to
     submit information about their USS and for all stakeholders to query for a
     USS Instances matching certain parameters.
-  version: v3
+  version: v4
   title: UTM USS Service Discovery
   termsOfService: >
 

--- a/utm-domains/utm-domain-commons.yaml
+++ b/utm-domains/utm-domain-commons.yaml
@@ -22,11 +22,8 @@ info:
       MUST reject that data submission. Some of these checks are explictly
       stated in the descriptions below. If you recognize any such checks that
       are not documented, please submit an issue report on github.
-  version: v3
+  version: v4
   title: UTM models
-  externalDocs:
-    description: The USS Specification document is a key enabler to this API.
-    url: https://only.available.directly.from.nasa/this.has.to.be.a.url/ugh
 definitions:
   data_accessibility:
     description: >-
@@ -71,12 +68,8 @@ definitions:
       5. **NOTICE**
         This issue is provided for situational awareness. Planning by operators and USSs may be affected.
       6. **INFORMATIONAL**
-        This issue is provided for situational awareness.
-      Note that this approach leverages RFC 5424: "The Syslog Protocol." By
-      taking this approach, there is the possibility of formalizing UTMMessaging
-      with more elements of the RFC to allow for compatibility with other
-      logging systems.
-      https://tools.ietf.org/html/rfc5424
+          This issue is provided for situational awareness. Note that this approach leverages RFC 5424: "The Syslog Protocol." By taking this approach, there is the possibility of formalizing UTMMessaging with more elements of the RFC to allow for compatibility with other logging systems. https://tools.ietf.org/html/rfc5424
+
     type: string
     enum:
       - EMERGENCY
@@ -376,8 +369,7 @@ definitions:
       - priority_status
     properties:
       priority_level:
-        $ref: >-
-          https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/severity
+        $ref: '#/definitions/severity'
       priority_status:
         type: string
         description: >-
@@ -921,8 +913,7 @@ definitions:
         maxLength: 100
         example: '2015-08-20T14:11:57.345Z'
       severity:
-        $ref: >-
-          https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/severity
+        $ref: '#/definitions/severity'
       message_type:
         description: >-
           The type of message. An enum to constrain messages and allow better
@@ -970,11 +961,9 @@ definitions:
           - UNAUTHORIZED_AIRSPACE_ENTRY
           - OTHER_SEE_FREE_TEXT
       last_known_position:
-        $ref: >-
-          https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/Position
+        $ref: '#/definitions/Position'
       contingency:
-        $ref: >-
-          https://raw.githubusercontent.com/nasa/utm-apis/v4-draft/utm-domains/utm-domain-commons.yaml#/definitions/ContingencyPlan
+        $ref: '#/definitions/ContingencyPlan'
       prev_message_id:
         description: >-
           A message_id of a previously sent message that has relevance or
@@ -1044,8 +1033,8 @@ definitions:
         example: 00000000-0000-4444-8888-FEEDDEADBEEF
       permitted_uas:
         description: >-
-           T h e   t y p e s   o f   U A S   operations t h a t   a r e   p e r m i t t e d   w i t h i n   t h e   b o u n d s   o f   
-          t h e   c o n s t r a i n t .  When used in conjunction with permitted_gufis, the
+          The types of UAS operations that are permitted within the bound of
+          the constraint. When used in conjunction with permitted_gufis, the
           filters are an 'OR' relationship. Any operation that matches either
           filter is allowed within the bounds of the constraint.  This list of
           permitted_uas types is not to be considered a final version.  It is
@@ -1069,8 +1058,8 @@ definitions:
           - NONE
       permitted_gufis:
         description: >-
-           T h e  specific   U A S   operations t h a t   a r e   p e r m i t t e d   w i t h i n   t h e   b o u n d s   o f   
-          t h e   c o n s t r a i n t .  When used in conjunction with permitted_uas, the
+          The specific UAS operations that are permitted within the counds of
+          the constraint.  When used in conjunction with permitted_uas, the
           filters are an 'OR' relationship. Any operation that matches either
           filter is allowed within the bounds of the constraint.  The protocol
           for adding the appropriate GUFIs to this array needs to be discussed.

--- a/utm-domains/utm-domain-geojson.yaml
+++ b/utm-domains/utm-domain-geojson.yaml
@@ -24,7 +24,7 @@
 
 info:
   description: "UTM geogrpahy model (swagger domain)"
-  version: 'v1'
+  version: 'v4'
   title: UTM Geography Model
 
 #

--- a/vehicle/swagger.yaml
+++ b/vehicle/swagger.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 'v1'
+  version: 'v4'
   title: Vehicle Registration
   description: Validates that the vehicle ID was properly registered for a NASA event.
   contact:


### PR DESCRIPTION
fix unprintable chars.
fix cannot self-reference over FQ URL

For APIs,
published v3 on swaggerhub and created v4 as new default
Note that all swaggerhub API pages have errors resolving the domain, but now those are the only category of errors.