### PR TITLE
sort in query must be of type array: "string"

### DIFF
--- a/uss-api/swagger.yaml
+++ b/uss-api/swagger.yaml
@@ -436,7 +436,7 @@ paths:
           in: query
           description: >-
             Field name(s) to use for sorting records. If multiple fields
-            are provided, the sorting is based on the ordered priorty of that
+            are provided, the sorting is based on the ordered priority of that
             list.  Note that the enum provided designates the required fields
             that a USS must support. A USS may decide to support additional
             fields, but how that USS communicates that option is out of scope
@@ -452,7 +452,7 @@ paths:
           collectionFormat: csv
           maxItems: 3
           minItems: 1
-          default: submit_time
+          default: ["submit_time"]
         - name: sort_increasing
           in: query
           description: >-


### PR DESCRIPTION
Running a validation using goswagger reveals this error:

swagger.yaml" is invalid against swagger specification 2.0. see errors :
- default value for sort in query does not validate its schema
- sort in query must be of type array: "string"

Passes validation after the change.